### PR TITLE
Add optimisation for polysphere solver

### DIFF
--- a/src/lib/polysphereSolver.js
+++ b/src/lib/polysphereSolver.js
@@ -144,6 +144,26 @@ export default function solvePolyspheres(board, unusedPieces, onSolution) {
   };
 
   /**
+   * Find the coordinates of the anchor points for a piece, given the starting
+   * coordinates.
+   *
+   * Similar to the normalize function, but instead of only aligning the top
+   * left piece to (0,0), it will return a list of pieces with each different
+   * tile aligned to (0,0).
+   *
+   * @param {*} startCoords
+   * @returns
+   */
+  const findAnchorPoints = (startCoords) => {
+    const points = [];
+    const coords = normalize(startCoords);
+    coords.forEach(([x, z]) => {
+      points.push(coords.map(([cx, cz]) => [cx - x, cz - z]));
+    });
+    return points;
+  };
+
+  /**
    * Recursively attempts to solve the polysphere puzzle.
    *
    * @param {string[][]} board The polysphere board.
@@ -168,26 +188,28 @@ export default function solvePolyspheres(board, unusedPieces, onSolution) {
     // For each unused piece...
     for (let i = 0; i < unusedPieces.length; i++) {
       const piece = unusedPieces[i];
-      const orientations = getAllOrientations(piece.coords);
       // ...For each orientation (rotation or flip) of this piece...
-      for (const orientation of orientations) {
-        if (canPlacePiece(board, orientation, startRow, startCol)) {
-          // ...Place the piece
-          const newBoard = placePiece(
-            board,
-            piece,
-            orientation,
-            startRow,
-            startCol
-          );
-          const remainingPieces = [
-            ...unusedPieces.slice(0, i),
-            ...unusedPieces.slice(i + 1),
-          ];
-          // ...Attempt to solve the board with this piece placed
-          solveRecursive(newBoard, remainingPieces, solutions);
-        }
-      }
+      getAllOrientations(piece.coords).forEach((orientation) => {
+        // ...And for each anchor point of this piece...
+        findAnchorPoints(orientation).forEach((anchor) => {
+          if (canPlacePiece(board, anchor, startRow, startCol)) {
+            // ...Place the piece
+            const newBoard = placePiece(
+              board,
+              piece,
+              anchor,
+              startRow,
+              startCol
+            );
+            const remainingPieces = [
+              ...unusedPieces.slice(0, i),
+              ...unusedPieces.slice(i + 1),
+            ];
+            // ...Attempt to solve the board with this piece placed
+            solveRecursive(newBoard, remainingPieces, solutions);
+          }
+        });
+      });
     }
   };
   solveRecursive(board, unusedPieces, []);


### PR DESCRIPTION
## Significant optimisation for Polysphere solver algorithm correctness and efficiency
- Now checks different anchor points for placing shape pieces.
- Solver is now several orders of magnitude faster at finding each solution and also finds a huge amount more solutions that were previously not covered.

Before vs after:

![Screenshot 2024-11-30 133522](https://github.com/user-attachments/assets/ae71201f-207f-41d7-8b0c-39d984cb47f0)

Starting with only the red piece in the top left in both cases:
- The original algorithm would find only 37 solutions before finishing.
- The new algorithm can find over 1000 solutions in the same time.
  - If left a little longer it finds well over 15,000 solutions. Not sure how many it finds before halting since I didn't test running it for that long.
